### PR TITLE
Bump Command Implementation

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -1018,6 +1018,24 @@ async def _menu(ctx):
     else:
         await ctx.send("Discord ID not attached to existing account \nUse !register (osu_username)")
 
+# Opens the random map or selected map menu if available
+@client.command(aliases=['b', 'Bump', 'bump'])
+async def _bump(ctx):
+    if is_registered(ctx.author.id):
+        playerState = get_player_state(ctx.author.id)
+        if("rmap" in playerState) or ("map@" in playerState): #If player is choosing a random map or has chosen a map
+            for menus in cashed_messages:
+                if ctx.author.id in menus: 
+                    message = await ctx.channel.fetch_message(menus[1])
+                    newMessage = await ctx.send(embed=message.embeds[0]) #Resend the embed message
+                    for react in message.reactions:
+                        await newMessage.add_reaction(react) #Add the reactions in the old message
+                    cashed_messages.append([ctx.author.id, newMessage.id]) #cache the new message
+                    await message.delete() #Delete old message
+                    cashed_messages.remove(menus) #Remove old message from cache
+    else:
+        await ctx.send("Discord ID not attached to existing account \nUse !register (osu_username)")
+
 
 # Opens the inventory menu at a specified page Closes other menus
 # Also adds that message to the message cash
@@ -1036,6 +1054,19 @@ async def _inventory_menu(ctx, page=0):
         await reaction_response("💼", ctx.author.id, message)
     else:
         await ctx.send("Discord ID not attached to existing account \nUse !register (osu_username)")
+
+
+@client.command(aliases=['il','IL','InventoryList','inventorylist','invlist','ilist'])
+async def _inventory_list(ctx):
+    osu_name = get_osu_name(ctx.author.id)
+    card_ids = await get_all_cards(str(ctx.author.id))
+    embed = discord.Embed(title=f"Inventory menu for {osu_name}", description=f"You have {len(card_ids)} Cards\n")
+    for id in card_ids:
+        cardRef = card_reference_list.get(id)
+        bmap = map_list.get(cardRef[1])
+        embed.add_field(name=f"- {bmap[3]} ({bmap[4]})")
+    
+    await ctx.send(embed=embed)
 
 # Checks if a reaction can happen
 async def is_valid_member_reaction(discord_id, message_id):

--- a/bot.py
+++ b/bot.py
@@ -1055,19 +1055,6 @@ async def _inventory_menu(ctx, page=0):
     else:
         await ctx.send("Discord ID not attached to existing account \nUse !register (osu_username)")
 
-
-@client.command(aliases=['il','IL','InventoryList','inventorylist','invlist','ilist'])
-async def _inventory_list(ctx):
-    osu_name = get_osu_name(ctx.author.id)
-    card_ids = await get_all_cards(str(ctx.author.id))
-    embed = discord.Embed(title=f"Inventory menu for {osu_name}", description=f"You have {len(card_ids)} Cards\n")
-    for id in card_ids:
-        cardRef = card_reference_list.get(id)
-        bmap = map_list.get(cardRef[1])
-        embed.add_field(name=f"- {bmap[3]} ({bmap[4]})")
-    
-    await ctx.send(embed=embed)
-
 # Checks if a reaction can happen
 async def is_valid_member_reaction(discord_id, message_id):
     if [discord_id, message_id] not in cashed_messages:


### PR DESCRIPTION
Resends embed and re-adds reactions if player is choosing a map or is setting a score on a selected map. Based on how the menus work, re-adding the reactions should theoretically make it work. I've done minimum testing using my own bot with a few methods, so there may still be a few bugs.